### PR TITLE
Fix: built 에러 해결을 위해 사용하지 않는 변수 삭제 (#54)

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,9 +6,7 @@ import './styles/global.scss'
 const router = createBrowserRouter(
   routerData.map(routerElement => ({
     path: routerElement.path,
-    element: (
-      <GeneralLayout withAuth={routerElement.withAuth}>{routerElement.element}</GeneralLayout>
-    ),
+    element: <GeneralLayout>{routerElement.element}</GeneralLayout>,
   }))
 )
 

--- a/client/src/components/Common/Icon.tsx
+++ b/client/src/components/Common/Icon.tsx
@@ -1,0 +1,44 @@
+import SpriteIcon from '../../assets/sprite-icon.svg'
+
+type IconNameType =
+  | 'chatting-plus'
+  | 'chatting-dots'
+  | 'box-arrow-left'
+  | 'box-arrow-right'
+  | 'calendar'
+  | 'camera'
+  | 'check-box'
+  | 'uncheck-box'
+  | 'x'
+  | 'skyblue-x-circle'
+  | 'pencil-box'
+  | 'trash-bin'
+  | 'alarm-gray'
+  | 'alarm-blue'
+  | 'calculator-gray'
+  | 'calculator-blue'
+  | 'file-text-fill-gray'
+  | 'file-text-fill-blue'
+  | 'check-square-gray'
+  | 'check-square-blue'
+  | 'add-person'
+  | 'profile'
+  | 'eye'
+  | 'eye-close'
+  | 'minus-square'
+  | 'plus-square'
+
+type IconProps = {
+  name: IconNameType
+  size?: number
+}
+
+function Icon({ name, size = 24 }: IconProps) {
+  return (
+    <svg width={size} height={size}>
+      <use href={`${SpriteIcon}#${name}`} />
+    </svg>
+  )
+}
+
+export default Icon

--- a/client/src/components/PlanDetail/PlanElement/Tapbar.tsx
+++ b/client/src/components/PlanDetail/PlanElement/Tapbar.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import styles from './Tapbar.module.scss'
 import Icon from '../../Common/Icon'
 

--- a/client/src/layout/GeneralLayout.tsx
+++ b/client/src/layout/GeneralLayout.tsx
@@ -3,10 +3,10 @@ import style from './GeneralLayout.module.scss'
 
 type GeneralLayoutProps = {
   children: React.ReactNode
-  withAuth: boolean
+  // withAuth: boolean
 }
 
-function GeneralLayout({ children, withAuth }: GeneralLayoutProps) {
+function GeneralLayout({ children }: GeneralLayoutProps) {
   return (
     <div className={style.container}>
       <Navbar />

--- a/client/src/pages/Planner.tsx
+++ b/client/src/pages/Planner.tsx
@@ -1,4 +1,4 @@
-import { SetStateAction, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import Icon from '../components/Common/Icon'
 import styles from './Planner.module.scss'
 import getCurrentUserPlanner from '../apis/planner'


### PR DESCRIPTION
- routerData에서 넘겨주는 withAuth 를 App, GeneralLayout 에서 삭제
- Tapbar에서 사용되지 않는데 import된  useState 삭제
- Planner 에서 사용되지 않는데 import된 SetStateAction 삭제