### PR TITLE
Feat: 로그인 response 로 오는 user info 저장

### DIFF
--- a/client/src/components/Common/Navbar.tsx
+++ b/client/src/components/Common/Navbar.tsx
@@ -3,10 +3,11 @@ import { NavBarContent } from '../../router/routerData'
 import styles from './Navbar.module.scss'
 import NavbarProfile from './NavbarProfile'
 import LogoutBtn from './LogoutBtn'
-
-const ISLOGIN = true
+import { useRecoilValue } from 'recoil'
+import { userInfo } from '../../store/store'
 
 function Navbar() {
+  const { userId: isLogin } = useRecoilValue(userInfo)
   return (
     <div className={styles.container}>
       <ul>
@@ -25,7 +26,7 @@ function Navbar() {
           )
         })}
       </ul>
-      {ISLOGIN && <LogoutBtn />}
+      {isLogin && <LogoutBtn />}
     </div>
   )
 }

--- a/client/src/components/Common/NavbarProfile.tsx
+++ b/client/src/components/Common/NavbarProfile.tsx
@@ -1,22 +1,25 @@
 import { NavLink } from 'react-router-dom'
 import styles from './NavbarProfile.module.scss'
 import Icon from './Icon'
-
-const 로그인여부 = false
-const profile = 'https://pbs.twimg.com/media/FMKsE-IaAAEFwFk.jpg'
+import { useRecoilValue } from 'recoil'
+import { userInfo } from '../../store/store'
 
 function NavbarProfile() {
+  const userinfo = useRecoilValue(userInfo)
+
   return (
     <li>
-      <NavLink to={로그인여부 ? '/profile' : '/user/login'}>
+      <NavLink to={userinfo.userId ? '/profile' : '/user/login'}>
         <div className={styles.profileBox}>
-          {profile && 로그인여부 ? (
-            <img src={profile} alt='profile' />
+          {userinfo.userId && userinfo.profileImgUrl ? (
+            <img src={userinfo.profileImgUrl} alt='profile' />
           ) : (
             <Icon name='profile' size={70} />
           )}
         </div>
-        <div className={styles.profileName}>{로그인여부 ? '유저이름' : '로그인/회원가입'}</div>
+        <div className={styles.profileName}>
+          {userinfo.userId ? userinfo.userNickname : '로그인/회원가입'}
+        </div>
       </NavLink>
     </li>
   )

--- a/client/src/pages/SignIn.tsx
+++ b/client/src/pages/SignIn.tsx
@@ -7,13 +7,6 @@ import { signIn } from '../apis/user'
 import useRouter from '../hooks/useRouter'
 import styles from './SignIn.module.scss'
 
-// 로그인 후 들어오는 userinfo 가짜 데이터
-const UserInformation = {
-  userId: 1,
-  userNickname: '설화',
-  email: 'test@test.com',
-}
-
 type SignInViewProps = {
   submitSignIn: (event: React.FormEvent<HTMLFormElement>) => void
 }
@@ -35,11 +28,10 @@ function SignInView({ submitSignIn }: SignInViewProps) {
 }
 
 type responseDataType = {
-  userInfo: {
-    userId: number
-    userNickname: string
-    email: string
-  }
+  userId: number
+  userNickname: string
+  email: string
+  profileImgUrl: string
 }
 
 function SignIn() {
@@ -55,7 +47,12 @@ function SignIn() {
     const { status, data }: { status: number; data: responseDataType } = response!
 
     if (status === 200) {
-      setUserInfo(UserInformation) // 응답으로 받은 유저 정보 Recoil & 세션 스토리지 저장
+      setUserInfo({
+        userId: data.userId,
+        userNickname: data.userNickname,
+        email: data.email,
+        profileImgUrl: data.profileImgUrl,
+      })
       routeTo('/')
     } else if (status === 403) {
       alert('이메일 또는 비밀번호를 확인해 주세요')

--- a/client/src/store/store.ts
+++ b/client/src/store/store.ts
@@ -1,11 +1,10 @@
 import { atom, RecoilState, DefaultValue } from 'recoil'
 
 type UserInfoType = {
-  userId?: number
-  userNickname?: string
-  profileImg?: string | null
-  plannerCount?: number
-  friends?: number[] // 닉네임은 중복될 수 있으니 userId
+  userId: number
+  userNickname: string
+  profileImgUrl: string
+  email: string
 }
 
 type AtomEffectParameterType<T> = {


### PR DESCRIPTION
- 로그인 성공시 response body로 오는 { userId, userNickname, profileImgUrl, email } 을 recoil  & 세션스토리지에 저장
- 로그인 성공시 Navbar의 profile 변경
  - 프로필 이미지가 있다면 프로필 기본 아이콘 → 프로필 이미지로 변경
  - 프로필 아이콘(또는 프로필 이미지) 클릭시 프로필 페이지로 이동
  - '로그인/회원가입' → 닉네임으로 변경
- 로그인 상태에서만 로그아웃 버튼 보이도록 변경