### PR TITLE
Refactor: Password, PasswordCheck 컴포넌트 리팩토링 (#92)

### DIFF
--- a/client/src/components/Profile/RenderEdit.tsx
+++ b/client/src/components/Profile/RenderEdit.tsx
@@ -14,12 +14,13 @@ function RenderEdit() {
 
   return (
     <form className={styles.entireContainer}>
-      <Password register={register} dirtyFields={dirtyFields} errors={errors} />
+      <Password register={register} dirtyFields={dirtyFields} errors={errors} isEdit={'새 '} />
       <PasswordCheck
         register={register}
         dirtyFields={dirtyFields}
         errors={errors}
         getValues={getValues}
+        isEdit={'새 '}
       />
       <button type='submit' className={styles.confirmButton}>
         확인

--- a/client/src/components/SignUp/Password.tsx
+++ b/client/src/components/SignUp/Password.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ReactHookFormProps } from '../../types/signUpTypes'
+import { PasswordProps } from '../../types/signUpTypes'
 import styles from './Form.module.scss'
 import ShowPasswordButton from './ShowPasswordButton'
 
@@ -7,7 +7,7 @@ const passwordReg =
   // eslint-disable-next-line no-useless-escape
   /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[~!@#$%^&*(),.?`'":{}|<>_+\-=\[\]])[a-zA-Z0-9~!@#$%^&*(),.?`'":{}|<>_+\-=\[\]]+$/
 
-function Password({ register, dirtyFields, errors }: ReactHookFormProps) {
+function Password({ register, dirtyFields, errors, isEdit = '' }: PasswordProps) {
   const [showPassword, setShowPassword] = useState<boolean>(false)
 
   const handleShow = () => {
@@ -37,7 +37,7 @@ function Password({ register, dirtyFields, errors }: ReactHookFormProps) {
 
   return (
     <label className={styles.label} htmlFor='password'>
-      비밀번호
+      {`${isEdit}비밀번호`}
       <div className={styles.inputErrorBox}>
         <input
           id='password'

--- a/client/src/components/SignUp/PasswordCheck.tsx
+++ b/client/src/components/SignUp/PasswordCheck.tsx
@@ -3,7 +3,13 @@ import { PasswordCheckProps } from '../../types/signUpTypes'
 import styles from './Form.module.scss'
 import ShowPasswordButton from './ShowPasswordButton'
 
-function PasswordCheck({ register, dirtyFields, errors, getValues }: PasswordCheckProps) {
+function PasswordCheck({
+  register,
+  dirtyFields,
+  errors,
+  getValues,
+  isEdit = '',
+}: PasswordCheckProps) {
   const [showPasswordCheck, setShowPasswordCheck] = useState<boolean>(false)
 
   const handleShow = () => {
@@ -25,7 +31,7 @@ function PasswordCheck({ register, dirtyFields, errors, getValues }: PasswordChe
 
   return (
     <label className={styles.label} htmlFor='passwordCheck'>
-      비밀번호 확인
+      {`${isEdit}비밀번호 확인`}
       <div className={styles.inputErrorBox}>
         <input
           id='passwordCheck'

--- a/client/src/types/signUpTypes.ts
+++ b/client/src/types/signUpTypes.ts
@@ -20,8 +20,13 @@ export interface ReactHookFormProps {
   errors: FieldErrors<FormValueType>
 }
 
+export interface PasswordProps extends ReactHookFormProps {
+  isEdit?: string
+}
+
 export interface PasswordCheckProps extends ReactHookFormProps {
   getValues: UseFormGetValues<FormValueType>
+  isEdit?: string
 }
 
 export interface SignUpViewProps extends PasswordCheckProps {


### PR DESCRIPTION
- 프로필/비밀번호 변경 페이지에서 label만 변경하여 재사용할 수 있도록 옵셔널한 props로 '새' 라는 글자를 내려줌