### PR TITLE
Feat: useLogout 커스텀 훅 완성 (#95)

### DIFF
--- a/client/src/components/Common/LogoutBtn.tsx
+++ b/client/src/components/Common/LogoutBtn.tsx
@@ -1,20 +1,12 @@
-import { useResetRecoilState } from 'recoil'
 import Icon from './Icon'
 import styles from './LogoutBtn.module.scss'
-import { userInfo } from '../../store/store'
-import useRouter from '../../hooks/useRouter'
+import useLogout from '../../hooks/useLogout'
 
 function LogoutBtn() {
-  const resetUserInfo = useResetRecoilState(userInfo)
-  const { routeTo } = useRouter()
-  const handleLogout = () => {
-    resetUserInfo()
-    routeTo(0)
-    // 서버에 로그아웃 요청 후 성공하면 새로고침
-  }
+  const logout = useLogout()
 
   return (
-    <button type='button' className={styles.logout} onClick={handleLogout}>
+    <button type='button' className={styles.logout} onClick={logout}>
       <Icon name='box-arrow-left' size={24} />
       <span>logout</span>
     </button>

--- a/client/src/hooks/useLogout.ts
+++ b/client/src/hooks/useLogout.ts
@@ -1,0 +1,18 @@
+import { useResetRecoilState } from 'recoil'
+import { userInfo } from '../store/store'
+import useRouter from './useRouter'
+
+const useLogout = () => {
+  const resetUserInfo = useResetRecoilState(userInfo)
+  const { routeTo } = useRouter()
+
+  const logOut = () => {
+    resetUserInfo()
+    sessionStorage.removeItem('token')
+    routeTo(0)
+  }
+
+  return logOut
+}
+
+export default useLogout


### PR DESCRIPTION
1. 유저가 로그아웃 버튼을 누른 경우
2. 서버에서 401 Unauthorized 응답을 한 모든 경우 에서 공통적으로 사용 가능한 useLogout 커스텀 훅 생성

- 세션스토리지, 리코일 저장소에 있는 유저 정보 리셋
- 세션스토리지의 토큰 리셋
- 현재 페이지 새로고침
  - 현재 페이지가 로그인이 필요한 페이지라면 로그인 페이지로 이동됨