### PR TITLE
fix: 그룹 멤버 추가 성공시 오는 웹소켓 응답을 groupMember 에 추가

### DIFF
--- a/client/src/pages/PlanDetail.tsx
+++ b/client/src/pages/PlanDetail.tsx
@@ -543,6 +543,8 @@ function PlanDetail() {
             setEditingScheduleId(-1)
             setScheduleData(initialScheduleData)
             setIsScheduleEditorOpened(false)
+          } else if (resBody.type === 'add-user') {
+            setGroupMember(members => [...members, resBody.msg])
           }
         }
       }


### PR DESCRIPTION
- 머지 과정 중 삭제 된 resBody.type === 'add-user' 일 때의 로직 다시 추가